### PR TITLE
Adding 'contains' method

### DIFF
--- a/public/js/data-structures/queue.structure.js
+++ b/public/js/data-structures/queue.structure.js
@@ -43,4 +43,21 @@ export default class Queue {
     toString() {
         return this.items.toString();
     }
+
+    // Check if an item exists in the queue using linear search
+    // For maze nodes, item should be compared by its x,y coordinates
+    contains(item) {
+        // If array is empty or item wasn't provided
+        if (this.isEmpty() || !item) return false;
+        
+        // If item is an object with x,y coordinates (maze node)
+        if (item.x !== undefined && item.y !== undefined) {
+            return this.items.some(element => 
+                element.x === item.x && element.y === item.y
+            );
+        }
+        
+        // For primitive values or other objects
+        return this.items.includes(item);
+    }
 }

--- a/public/js/data-structures/stack.structure.js
+++ b/public/js/data-structures/stack.structure.js
@@ -43,4 +43,21 @@ export default class Stack {
     toString() {
         return this.items.toString();
     }
+
+    // Check if an item exists in the stack using linear search
+    // For maze nodes, item should be compared by its x,y coordinates
+    contains(item) {
+        // If array is empty or item wasn't provided
+        if (this.isEmpty() || !item) return false;
+        
+        // If item is an object with x,y coordinates (maze node)
+        if (item.x !== undefined && item.y !== undefined) {
+            return this.items.some(element => 
+                element.x === item.x && element.y === item.y
+            );
+        }
+        
+        // For primitive values or other objects
+        return this.items.includes(item);
+    }
 }


### PR DESCRIPTION
# The `contains` method
With this single commit, now both stack and queue are able to look for an existing element in their items array.
This method was created thinking about avoiding to enter in an infinite cycle when executing dfs or bfs algorithm.